### PR TITLE
Point formula and README at renamed homebrew-tap repo

### DIFF
--- a/Formula/autamo.rb
+++ b/Formula/autamo.rb
@@ -2,17 +2,17 @@ class Autamo < Formula
   desc "Autamo - A Node.js application for git operations"
   homepage "https://autamo.ai"
   version "0.74.0"
-  url "https://github.com/tryautamo/homebrew-autamo/releases/download/v0.74.0/autamo-arm64"
+  url "https://github.com/tryautamo/homebrew-tap/releases/download/v0.74.0/autamo-arm64"
   sha256 "3a0ad7897c316f15080badde4cdf64cac634a8e8e98adfd36878fc096dce9b26"
   license "MIT"
 
   on_arm do
-    url "https://github.com/tryautamo/homebrew-autamo/releases/download/v0.74.0/autamo-arm64"
+    url "https://github.com/tryautamo/homebrew-tap/releases/download/v0.74.0/autamo-arm64"
     sha256 "3a0ad7897c316f15080badde4cdf64cac634a8e8e98adfd36878fc096dce9b26"
   end
 
   # on_intel do
-  #   url "https://github.com/tryautamo/homebrew-autamo/releases/download/v0.6.2/autamo-x64"
+  #   url "https://github.com/tryautamo/homebrew-tap/releases/download/v0.6.2/autamo-x64"
   #
   # end
 

--- a/README.md
+++ b/README.md
@@ -7,9 +7,11 @@ It contains the Homebrew formula used to install the `autamo` binary:
 ## Install
 
 ```bash
-brew tap tryautamo/homebrew-autamo
-brew install autamo
+brew install tryautamo/tap/autamo
 ```
+
+Using the fully-qualified name installs (and implicitly trusts) just this
+formula, so it works on Homebrew 6.0+ without a separate `brew trust` step.
 
 ## Upgrade
 


### PR DESCRIPTION
The tap repository was renamed `homebrew-autamo` → `homebrew-tap`. This updates the references that pointed at the old name.

## Changes
- `Formula/autamo.rb` — release-download URLs now point at `tryautamo/homebrew-tap/releases/...`
- `README.md` — install instructions switched to the fully-qualified `brew install tryautamo/tap/autamo`, which installs and implicitly trusts just this formula (no separate `brew trust` step on Homebrew 6.0+)

## Notes
The existing release assets (v0.74.0 `autamo-arm64`) moved with the repo during the GitHub rename, so the new URLs resolve. Companion URL/publish-target updates in `dispatch` and `autamo-electron` are handled separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)